### PR TITLE
Update chapter navigation labels

### DIFF
--- a/src/components/reader-navigation.js
+++ b/src/components/reader-navigation.js
@@ -15,11 +15,17 @@ type Props = {
 
 const getChapterLabel = (chapter): string => {
   const parts = [
-    chapter.volumeNumber && `Vol. ${chapter.volumeNumber}`,
+    chapter.volumeNumber &&
+      chapter.volumeNumber !== '0' &&
+      `Vol. ${chapter.volumeNumber}`,
     chapter.chapterNumber && `Chapter ${chapter.chapterNumber}`,
-  ];
+  ].filter(Boolean);
 
-  return parts.filter(Boolean).join(' - ');
+  if (parts.length === 0) {
+    return chapter.title;
+  }
+
+  return parts.join(' - ');
 };
 
 const ReaderNavigation = ({

--- a/src/components/reader-navigation.js
+++ b/src/components/reader-navigation.js
@@ -13,6 +13,15 @@ type Props = {
   seriesChapters: Series,
 };
 
+const getChapterLabel = (chapter): string => {
+  const parts = [
+    chapter.volumeNumber && `Vol. ${chapter.volumeNumber}`,
+    chapter.chapterNumber && `Chapter ${chapter.chapterNumber}`,
+  ];
+
+  return parts.filter(Boolean).join(' - ');
+};
+
 const ReaderNavigation = ({
   chapter,
   collectionSlug,
@@ -22,7 +31,7 @@ const ReaderNavigation = ({
   const chapterSelectorOptions = seriesChapters
     ? seriesChapters.map(c => ({
         value: c.slug,
-        label: `Chapter ${c.chapterNumber}`,
+        label: getChapterLabel(c),
       }))
     : [{ value: '', label: '' }];
 


### PR DESCRIPTION
For series like [Devilman](https://mangadex.org/manga/2875), chapters aren't present at all. This results in a list that says "chapter undefined, chapter undefined, chapter undefined", which isn't nice.

This updates the chapter navigation logic so that it uses all the information available to format a nice label.