### PR TITLE
Update URL structure

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -53,13 +53,14 @@ const api = {
   ) => instance.delete(`/collection/${collectionSlug}/bookmark/${seriesId}`),
   fetchChapter: (id: string) => {
     const { siteId, seriesSlug, chapterSlug } = utils.getIdComponents(id);
-
     return instance.get(`/chapter`, {
       params: { siteId, seriesSlug, chapterSlug },
     });
   },
-  fetchSeries: (siteId: string, seriesSlug: string) =>
-    instance.get(`/series`, { params: { siteId, seriesSlug } }),
+  fetchSeries: (id: string) => {
+    const { siteId, seriesSlug } = utils.getIdComponents(id);
+    return instance.get(`/series`, { params: { siteId, seriesSlug } });
+  },
   fetchSeriesByUrl: (url: string) =>
     instance.get(`/series`, { params: { url } }),
 };

--- a/src/app.js
+++ b/src/app.js
@@ -39,12 +39,13 @@ export default class App extends Component<{}> {
         <StandaloneStatusBar />
         <ErrorBoundary>
           <Switch>
-            <Route path="/read/:chapterId" component={ReaderView} />
+            <Route path="/read/:chapterId" exact component={ReaderView} />
             <Route
               path="/c/:collectionSlug/read/:chapterId"
               component={ReaderView}
+              exact
             />
-            <Route path="/c/:collectionSlug" component={FeedView} />
+            <Route path="/c/:collectionSlug" exact component={FeedView} />
             <Route path="/login" component={LogInView} />
             <Route path="/about" component={AboutView} />
             <Route path="/home" component={HomeView} />

--- a/src/app.js
+++ b/src/app.js
@@ -39,12 +39,9 @@ export default class App extends Component<{}> {
         <StandaloneStatusBar />
         <ErrorBoundary>
           <Switch>
+            <Route path="/read/:chapterId" component={ReaderView} />
             <Route
-              path="/read/:siteId/:seriesSlug/:chapterSlug+"
-              component={ReaderView}
-            />
-            <Route
-              path="/c/:collectionSlug/read/:siteId/:seriesSlug/:chapterSlug+"
+              path="/c/:collectionSlug/read/:chapterId"
               component={ReaderView}
             />
             <Route path="/c/:collectionSlug" component={FeedView} />

--- a/src/components/reader-chapter-link.js
+++ b/src/components/reader-chapter-link.js
@@ -16,17 +16,7 @@ type Props = {
 const ReaderChapterLink = ({ collectionSlug, chapter, children }: Props) => {
   const disabled = !chapter;
 
-  let to = '/';
-
-  if (chapter) {
-    const { siteId, seriesSlug } = utils.getIdComponents(chapter.id);
-    to = utils.getReaderUrl(
-      collectionSlug,
-      siteId,
-      seriesSlug,
-      chapter && chapter.slug,
-    );
-  }
+  const to = chapter ? utils.getReaderUrl(collectionSlug, chapter.id) : '/';
 
   return (
     <Link

--- a/src/containers/collection-feed.js
+++ b/src/containers/collection-feed.js
@@ -141,14 +141,7 @@ class Feed extends Component<Props, State> {
         ? utils.leastRecentChapter(unreadChapters)
         : utils.mostRecentChapter(allChapters);
 
-    history.push(
-      utils.getReaderUrl(
-        collection.slug,
-        series.site.id,
-        series.slug,
-        toChapter.slug,
-      ),
-    );
+    history.push(utils.getReaderUrl(collection.slug, toChapter.id));
   };
 
   renderSeriesPanel() {

--- a/src/store/reducers/chapters.js
+++ b/src/store/reducers/chapters.js
@@ -4,14 +4,14 @@ import { normalize } from 'normalizr';
 import schema from '../schema';
 import utils from '../../utils';
 
-import type { Id, SiteId, Slug, Chapter, ChapterMetadata } from '../../types';
+import type { Chapter, ChapterMetadata } from '../../types';
 import type { FetchStatusState, Thunk, ChapterAction } from '../types';
 
 type Action = ChapterAction;
 
 type State = {
   _status: FetchStatusState,
-  [id: Id]: Chapter | ChapterMetadata,
+  [id: string]: Chapter | ChapterMetadata,
 };
 
 export function isFullChapter(chapter: ?Chapter | ?ChapterMetadata): boolean {

--- a/src/store/reducers/collections.js
+++ b/src/store/reducers/collections.js
@@ -5,17 +5,17 @@ import schema from '../schema';
 import { shouldFetchSeries, fetchSeries } from './series';
 import utils from '../../utils';
 
-import type { Id, Slug, Collection } from '../../types';
+import type { Collection } from '../../types';
 import type { EntityStatus, Thunk, CollectionAction } from '../types';
 
 type Action = CollectionAction;
 
 type State = {
-  +_status: { [slug: Slug]: EntityStatus },
-  +[slug: Slug]: Collection,
+  +_status: { [slug: string]: EntityStatus },
+  +[slug: string]: Collection,
 };
 
-export function fetchCollectionIfNeeded(slug: Slug): Thunk {
+export function fetchCollectionIfNeeded(slug: string): Thunk {
   return (dispatch, getState) => {
     if (shouldFetchCollection(getState(), slug)) {
       dispatch(fetchCollection(slug));
@@ -25,7 +25,7 @@ export function fetchCollectionIfNeeded(slug: Slug): Thunk {
 
 const STALE_AFTER = 15 * 60; // 15 minutes
 
-function shouldFetchCollection(state: Object, slug: Slug): boolean {
+function shouldFetchCollection(state: Object, slug: string): boolean {
   const collections = state.collections;
   const status = collections._status[slug];
 
@@ -40,7 +40,7 @@ function shouldFetchCollection(state: Object, slug: Slug): boolean {
   }
 }
 
-function getSeriesIdForCollection(state: State, slug: Slug): ?(Id[]) {
+function getSeriesIdForCollection(state: State, slug: string): ?(string[]) {
   const collection = state.collections[slug];
 
   if (!collection) {
@@ -50,7 +50,7 @@ function getSeriesIdForCollection(state: State, slug: Slug): ?(Id[]) {
   return Object.keys(collection.bookmarks);
 }
 
-export function fetchCollection(slug: Slug): Thunk {
+export function fetchCollection(slug: string): Thunk {
   return (dispatch, getState, api) => {
     dispatch({
       type: 'SET_COLLECTION_ENTITY_STATUS',
@@ -98,7 +98,7 @@ export function fetchCollection(slug: Slug): Thunk {
   };
 }
 
-export function fetchSeriesForCollection(collectionSlug: Slug): Thunk {
+export function fetchSeriesForCollection(collectionSlug: string): Thunk {
   return (dispatch, getState, api) => {
     const state = getState();
     const seriesIds = getSeriesIdForCollection(state, collectionSlug);
@@ -118,7 +118,10 @@ export function fetchSeriesForCollection(collectionSlug: Slug): Thunk {
 /**
  * Delete a bookmark from a collection.
  */
-export function removeBookmark(collectionSlug: Slug, seriesId: Id): Thunk {
+export function removeBookmark(
+  collectionSlug: string,
+  seriesId: string,
+): Thunk {
   return (dispatch, getState, api) => {
     dispatch({
       type: 'REMOVE_BOOKMARK',
@@ -134,8 +137,8 @@ export function removeBookmark(collectionSlug: Slug, seriesId: Id): Thunk {
 }
 
 export function markSeriesAsRead(
-  collectionSlug: Slug,
-  seriesId: Id,
+  collectionSlug: string,
+  seriesId: string,
   lastReadAt: number,
 ): Thunk {
   return (dispatch, getState, api) => {

--- a/src/store/reducers/collections.js
+++ b/src/store/reducers/collections.js
@@ -110,8 +110,7 @@ export function fetchSeriesForCollection(collectionSlug: Slug): Thunk {
     const missingSeries = seriesIds.filter(id => shouldFetchSeries(state, id));
 
     missingSeries.forEach(id => {
-      const { siteId, seriesSlug } = utils.getIdComponents(id);
-      dispatch(fetchSeries(siteId, seriesSlug));
+      dispatch(fetchSeries(id));
     });
   };
 }

--- a/src/store/reducers/series.js
+++ b/src/store/reducers/series.js
@@ -4,17 +4,17 @@ import { normalize } from 'normalizr';
 import ms from 'milliseconds';
 import schema from '../schema';
 import utils from '../../utils';
-import type { SiteId, Id, Slug, Series } from '../../types';
+import type { Series } from '../../types';
 import type { EntityStatus, Thunk, SeriesAction } from '../types';
 
 type State = {
-  _status: { [id: Id]: EntityStatus },
-  [id: Id]: Series,
+  _status: { [id: string]: EntityStatus },
+  [id: string]: Series,
 };
 
 type Action = SeriesAction;
 
-export function fetchSeriesIfNeeded(seriesId: Id): Thunk {
+export function fetchSeriesIfNeeded(seriesId: string): Thunk {
   return (dispatch, getState) => {
     if (shouldFetchSeries(getState(), seriesId)) {
       dispatch(fetchSeries(seriesId));
@@ -24,7 +24,7 @@ export function fetchSeriesIfNeeded(seriesId: Id): Thunk {
 
 const STALE_AFTER = ms.hours(2) / 1000;
 
-export function shouldFetchSeries(state: Object, seriesId: Id): boolean {
+export function shouldFetchSeries(state: Object, seriesId: string): boolean {
   const seriesById = state.series;
   const status = seriesById._status[seriesId];
 
@@ -39,7 +39,7 @@ export function shouldFetchSeries(state: Object, seriesId: Id): boolean {
   }
 }
 
-export function fetchSeries(id: Id): Thunk {
+export function fetchSeries(id: string): Thunk {
   return (dispatch, getState, api) => {
     dispatch({
       type: 'SET_SERIES_ENTITY_STATUS',

--- a/src/store/reducers/series.js
+++ b/src/store/reducers/series.js
@@ -14,20 +14,19 @@ type State = {
 
 type Action = SeriesAction;
 
-export function fetchSeriesIfNeeded(siteId: SiteId, slug: Slug): Thunk {
+export function fetchSeriesIfNeeded(seriesId: Id): Thunk {
   return (dispatch, getState) => {
-    const id = utils.getId(siteId, slug);
-    if (shouldFetchSeries(getState(), id)) {
-      dispatch(fetchSeries(siteId, slug));
+    if (shouldFetchSeries(getState(), seriesId)) {
+      dispatch(fetchSeries(seriesId));
     }
   };
 }
 
 const STALE_AFTER = ms.hours(2) / 1000;
 
-export function shouldFetchSeries(state: Object, id: Id): boolean {
+export function shouldFetchSeries(state: Object, seriesId: Id): boolean {
   const seriesById = state.series;
-  const status = seriesById._status[id];
+  const status = seriesById._status[seriesId];
 
   switch (status && status.fetchStatus) {
     case 'fetching':
@@ -40,17 +39,15 @@ export function shouldFetchSeries(state: Object, id: Id): boolean {
   }
 }
 
-export function fetchSeries(siteId: SiteId, slug: Slug): Thunk {
+export function fetchSeries(id: Id): Thunk {
   return (dispatch, getState, api) => {
-    const id = utils.getId(siteId, slug);
-
     dispatch({
       type: 'SET_SERIES_ENTITY_STATUS',
       payload: { id, status: { fetchStatus: 'fetching', errorCode: null } },
     });
 
     api
-      .fetchSeries(siteId, slug)
+      .fetchSeries(id)
       .then(response => {
         const normalized = normalize(response.data, schema.series);
         dispatch({

--- a/src/store/types.js
+++ b/src/store/types.js
@@ -2,14 +2,7 @@
 
 import api from '../api';
 import type { Store as ReduxStore } from 'redux';
-import type {
-  Slug,
-  Id,
-  Collection,
-  Chapter,
-  ChapterMetadata,
-  Series,
-} from '../types';
+import type { Collection, Chapter, ChapterMetadata, Series } from '../types';
 
 type ActionType<A, B> = { +type: A, +payload: B };
 type ActionWithoutPayloadType<A> = { +type: A };
@@ -42,9 +35,9 @@ type StatusActionPayload = {|
 |};
 
 export type EntitiesPayload = {
-  collections?: { [slug: Slug]: Collection },
-  chapters?: { [id: Id]: Chapter | ChapterMetadata },
-  series?: { [id: Id]: Series },
+  collections?: { [slug: string]: Collection },
+  chapters?: { [id: string]: Chapter | ChapterMetadata },
+  series?: { [id: string]: Series },
 };
 
 export type AddEntitiesAction = ActionType<'ADD_ENTITIES', EntitiesPayload>;
@@ -52,20 +45,20 @@ export type AddEntitiesAction = ActionType<'ADD_ENTITIES', EntitiesPayload>;
 export type SetCollectionAction = ActionType<'SET_COLLECTION', Collection>;
 export type SetCollectionEntityStatusAction = ActionType<
   'SET_COLLECTION_ENTITY_STATUS',
-  { slug: Slug, status: EntityStatusActionPayload },
+  { slug: string, status: EntityStatusActionPayload },
 >;
 export type RemoveBookmarkAction = ActionType<
   'REMOVE_BOOKMARK',
-  { collectionSlug: Slug, seriesId: Id },
+  { collectionSlug: string, seriesId: string },
 >;
 export type MarkBookmarkAsReadAction = ActionType<
   'MARK_BOOKMARK_AS_READ',
-  { collectionSlug: Slug, seriesId: Id, lastReadAt: number },
+  { collectionSlug: string, seriesId: string, lastReadAt: number },
 >;
 export type SetSeriesAction = ActionType<'SET_SERIES', Series>;
 export type SetSeriesEntityStatusAction = ActionType<
   'SET_SERIES_ENTITY_STATUS',
-  { id: Id, status: EntityStatusActionPayload },
+  { id: string, status: EntityStatusActionPayload },
 >;
 export type SetChapterAction = ActionType<
   'SET_CHAPTER',

--- a/src/types.js
+++ b/src/types.js
@@ -1,17 +1,3 @@
-export type SiteId =
-  | 'helvetica-scans'
-  | 'jaiminis-box'
-  | 'manga-here'
-  | 'manga-updates'
-  | 'mangadex'
-  | 'mangakakalot'
-  | 'meraki-scans';
-
-// Component of a url (eg. "senryu-girl", "5", "en/0/1")
-export type Slug = string;
-// Full ID of a series/chapter (eg. "meraki-scans:senryu-girl:5")
-export type Id = string;
-
 export type Page = {
   id: string,
   url: string,

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,7 +83,7 @@ const utils = {
     utils.constructUrl(
       collectionSlug ? `c/${collectionSlug}` : null,
       'read',
-      chapterId.replace(/\//g, '%2F'),
+      encodeURIComponent(chapterId).replace(/%3A/g, ':'),
     ),
   getCollectionUrl: (collectionSlug: string) => `/c/${collectionSlug}`,
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,12 @@ import type { Bookmark, Collection, Chapter } from './types';
 
 const toDate = (n: number): Date => new Date(n * 1000);
 
+type IdComponents = {
+  siteId: string,
+  seriesSlug: string,
+  chapterSlug?: string,
+};
+
 const utils = {
   formatTimestamp: (n: number): string => ago(toDate(n)),
   formatAbsoluteTimestamp: (n: number) => {
@@ -28,24 +34,14 @@ const utils = {
   /**
    * Array Helpers
    */
-  getRandomItems: (arr: Array<mixed>, count: number = 1) =>
-    arr
-      .slice()
-      .sort(() => 0.5 - Math.random())
-      .slice(0, count),
-  flatten: (arr: Array<mixed>) => [].concat(...arr),
   groupBy,
 
   /**
    * Store helpers
    */
-  getId: (siteId: string, seriesSlug: string, chapterSlug: ?string) =>
-    [siteId, seriesSlug, chapterSlug].filter(Boolean).join(':'),
-  getIdComponents: (
-    id: string,
-  ): { siteId: string, seriesSlug: string, chapterSlug: ?string } => {
+  getIdComponents: (id: string): IdComponents => {
     const parts = id.split(':');
-    const components: any = {
+    const components: IdComponents = {
       siteId: parts[0],
       seriesSlug: parts[1],
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,6 +56,12 @@ const utils = {
 
     return components;
   },
+  toSeriesId: (chapterId: string) => {
+    return chapterId
+      .split(':')
+      .slice(0, 2)
+      .join(':');
+  },
 
   set,
 
@@ -76,19 +82,12 @@ const utils = {
     }
     return /^https?:\/\/[^ "]+$/.test(url);
   },
-  getReaderUrl: (
-    collectionSlug: ?string,
-    siteId: string,
-    seriesSlug: string,
-    chapterSlug: ?string,
-  ) =>
+  getReaderUrl: (collectionSlug: ?string, chapterId: string) =>
     '/' +
     utils.constructUrl(
       collectionSlug ? `c/${collectionSlug}` : null,
       'read',
-      siteId,
-      seriesSlug,
-      chapterSlug,
+      chapterId.replace(/\//g, '%2F'),
     ),
   getCollectionUrl: (collectionSlug: string) => `/c/${collectionSlug}`,
 


### PR DESCRIPTION
This PR almost entirely eliminates the concept of URL "components" from the codebase.

Poketo object IDs are made of three components joined by a colon (eg. `meraki-scans:senryu-girl:5`). Previously, there was a bunch of functions to convert between components and object IDs in order to support a URL structure like this: `/read/meraki-scans/senryu-girl/5`. I think I finally clued in to how silly it was to contort IDs to fit that purpose.

These changes update the URL structure to simply use the IDs: `/read/meraki-scans:senryu-girl:5`. After all, [colons are valid URL characters](https://www.quora.com/Is-it-safe-to-use-a-colon-in-the-path-of-a-URL).

With this change, we can remove a bunch of random Flow types used to distinguish the URL components too.