### PR TITLE
Fix stale unread status

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -20,6 +20,8 @@ export type AxiosError = {
   config: Object,
 };
 
+const SCRAPING_TIMEOUT = 8000;
+
 const instance = axios.create({
   baseURL: config.apiBaseUrl,
 });
@@ -54,18 +56,18 @@ const api = {
     const { siteId, seriesSlug, chapterSlug } = utils.getIdComponents(id);
     return instance.get(`/chapter`, {
       params: { siteId, seriesSlug, chapterSlug },
-      timeout: 8000,
+      timeout: SCRAPING_TIMEOUT,
     });
   },
   fetchSeries: (id: string) => {
     const { siteId, seriesSlug } = utils.getIdComponents(id);
     return instance.get(`/series`, {
       params: { siteId, seriesSlug },
-      timeout: 8000,
+      timeout: SCRAPING_TIMEOUT,
     });
   },
   fetchSeriesByUrl: (url: string) =>
-    instance.get(`/series`, { params: { url }, timeout: 8000 }),
+    instance.get(`/series`, { params: { url }, timeout: SCRAPING_TIMEOUT }),
 };
 
 export default api;

--- a/src/api.js
+++ b/src/api.js
@@ -22,7 +22,6 @@ export type AxiosError = {
 
 const instance = axios.create({
   baseURL: config.apiBaseUrl,
-  timeout: 8000,
 });
 
 const api = {
@@ -55,14 +54,18 @@ const api = {
     const { siteId, seriesSlug, chapterSlug } = utils.getIdComponents(id);
     return instance.get(`/chapter`, {
       params: { siteId, seriesSlug, chapterSlug },
+      timeout: 8000,
     });
   },
   fetchSeries: (id: string) => {
     const { siteId, seriesSlug } = utils.getIdComponents(id);
-    return instance.get(`/series`, { params: { siteId, seriesSlug } });
+    return instance.get(`/series`, {
+      params: { siteId, seriesSlug },
+      timeout: 8000,
+    });
   },
   fetchSeriesByUrl: (url: string) =>
-    instance.get(`/series`, { params: { url } }),
+    instance.get(`/series`, { params: { url }, timeout: 8000 }),
 };
 
 export default api;

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ const config: { [string]: string } = {
   discordInviteUrl: 'https://discord.gg/y5gVmY3',
   githubUrl: 'https://github.com/poketo',
   githubSiteUrl: 'https://github.com/poketo/site',
+  githubSiteIssueUrl: 'https://github.com/poketo/site/issues/new',
   githubServiceUrl: 'https://github.com/poketo/service',
   githubLibraryUrl: 'https://github.com/poketo/poketo',
   githubSupportedSites:

--- a/src/store/reducers/collections.js
+++ b/src/store/reducers/collections.js
@@ -23,7 +23,7 @@ export function fetchCollectionIfNeeded(slug: string): Thunk {
   };
 }
 
-const STALE_AFTER = 15 * 60; // 15 minutes
+const STALE_AFTER = 1 * 60; // 1 minute
 
 function shouldFetchCollection(state: Object, slug: string): boolean {
   const collections = state.collections;

--- a/src/store/reducers/collections.js
+++ b/src/store/reducers/collections.js
@@ -145,7 +145,6 @@ export function markSeriesAsRead(
       payload: { collectionSlug, seriesId, lastReadAt },
     });
 
-    // We don't handle the response since we pass this info optimistically.
     api.fetchMarkAsRead(collectionSlug, seriesId, lastReadAt).catch(err => {
       // swallow errors
     });

--- a/src/store/reducers/collections.js
+++ b/src/store/reducers/collections.js
@@ -2,7 +2,7 @@
 
 import { normalize } from 'normalizr';
 import schema from '../schema';
-import { shouldFetchSeries, fetchSeries } from './series';
+import { fetchSeriesIfNeeded } from './series';
 import utils from '../../utils';
 
 import type { Collection } from '../../types';
@@ -107,10 +107,8 @@ export function fetchSeriesForCollection(collectionSlug: string): Thunk {
       return;
     }
 
-    const missingSeries = seriesIds.filter(id => shouldFetchSeries(state, id));
-
-    missingSeries.forEach(id => {
-      dispatch(fetchSeries(id));
+    seriesIds.forEach(id => {
+      dispatch(fetchSeriesIfNeeded(id));
     });
   };
 }


### PR DESCRIPTION
When reading on one device and moving to another, chapters would often remain marked as unread. This is because Poketo heavily caches collection information, only re-fetching it (originally) after 15 days or when changes are made from the current device.

This PR reduces the cache time down to 1 minute (to avoid constant re-requests from navigating around) and ensures that the collection screen shows content, even when fetching is happening in the background.